### PR TITLE
Retry on ioexception

### DIFF
--- a/src/Database/CQL/IO/Client.hs
+++ b/src/Database/CQL/IO/Client.hs
@@ -232,6 +232,7 @@ request a = liftClient $ do
             ServerError  {} -> return True
             _               -> return False
         , const $ Handler $ \(_ :: ConnectionError) -> return True
+        , const $ Handler $ \(_ :: IOException)     -> return True
         ]
 
 getResponse :: (Tuple a, Tuple b) => Request k a b -> ClientState -> Word -> Client (Response k a b)


### PR DESCRIPTION
I was doing some testing of failure cases and was surprised to see that cleanly shutting down a cassandra node could cause a query to fail with a "connection refused" error.  Tracing through it, I found that `getResponse` was handling the node-status bookkeeping on `IOException` and rethrowing it to `request`, which itself did not choose to recover as it did on `ConnectionError`.