### PR TITLE
More async cleanups/fixes

### DIFF
--- a/src/Database/CQL/IO/Connection.hs
+++ b/src/Database/CQL/IO/Connection.hs
@@ -180,7 +180,13 @@ readLoop v g set tck i sck syn s lck = run `catch` logException `finally` cleanu
                 unless ok $
                     markAvailable tck sid
 
-    cleanup = do
+    -- This doesn't have to happen immediately (just "soon"); running
+    -- it asynchronously prevents FD leaks in a scenario where the
+    -- 'run' loop terminates _just_ before 'close' happens.  If the
+    -- cancel performed by 'close' were to happen while the reader is
+    -- blocked in modifyMVar_ (I don't believe Tickets.close nor
+    -- Sync.close can block), the socket would be leaked.
+    cleanup = async $ do
         Tickets.close (ConnectionClosed i) tck
         Vector.mapM_ (Sync.close (ConnectionClosed i)) syn
         S.shutdown sck S.ShutdownBoth


### PR DESCRIPTION
This patch series came into being when I realized the fd-use-after-close patch introduced an async exception bug -- if `Connection.close` were called after the read loop started to shutdown but while it was waiting for a writer release the write lock, it would interrupt the `modifyMVar_` call and the socket would be leaked.  After that, I started looking more closely and found a few other (potential) problems:

* If `Connection.validateSettings` throws (for example, if the Cassandra it's connected to goes down at an inopportune instant) it would close via `Connection.connect`'s `bracketOnError` after the read loop takes ownership of the socket.  I did manage to make that cause a "bad file descriptor" error in the read loop's receive call so it's not entirely theoretical.  Interestingly, `Network.Socket.close` is guarded by the socket's internal state flag, even though `send` and `recv` are not.  I wonder why that is.
* When destroying a `TimeoutManager`, _all_ the reaper's actions would be invoked, even the cancelled ones. Incidentally, this makes me nervous that a high-volume client could pile up a large number of cancelled but not yet expired timeout actions.  I didn't look into whether that's a real problem.
* If an async exception arrives during `Client.shutdown`, the shutdown process could be interrupted partway through (I think; I'm not sure any actual blocking occurs during shutdown to give an async exception the opportunity to show up when they're masked, but there are enough callbacky things that I wouldn't bet my life on it) and the various `ignore`s that happen during it could swallow the exception silently.  This patch was the one that showed up the `TimeoutManager` thing.  Before, a canceled action was `throwTo`ing itself inside an `ignore`.  After, that same canceled action was `throwTo`ing the parent thread and not getting ignored.