### PR TITLE
Try to connect to all the results of getAddrInfo

### DIFF
--- a/src/Database/CQL/IO/Client.hs
+++ b/src/Database/CQL/IO/Client.hs
@@ -318,7 +318,10 @@ init g s = liftIO $ do
     return x
   where
     mkConnection t h = do
-        a <- C.resolve h (s^.portnumber)
+        as <- C.resolve h (s^.portnumber)
+        NE.fromList as `tryAll` doConnect t
+
+    doConnect t a = do
         Logger.debug g $ msg (val "connecting to " +++ a)
         c <- C.connect (s^.connSettings) t (s^.protoVersion) g a
         Logger.info g $ msg (val "control connection: " +++ c)

--- a/src/Database/CQL/IO/Connection.hs
+++ b/src/Database/CQL/IO/Connection.hs
@@ -127,9 +127,9 @@ defSettings =
                        Nothing       -- keyspace
                        16384         -- receive buffer size
 
-resolve :: String -> PortNumber -> IO InetAddr
+resolve :: String -> PortNumber -> IO [InetAddr]
 resolve host port =
-    InetAddr . addrAddress . head <$> getAddrInfo (Just hints) (Just host) (Just (show port))
+    map (InetAddr . addrAddress) <$> getAddrInfo (Just hints) (Just host) (Just (show port))
   where
     hints = defaultHints { addrFlags = [AI_ADDRCONFIG], addrSocketType = Stream }
 


### PR DESCRIPTION
getAddrInfo returns multiple results for the resolution (including IPv4
and IPv6 addresses) and the right logic should be to try to connect in
order to all these addresses.

N.B.: getAddrInfo always returns an non-empty list unless it throws an
IO exception.

As an example, in my Linux system, resolving "localhost" returns 2 results, giving IPv6 first which usually would fail (unless you are using Cassandra with IPv6) and then IPv4 should be tried later in order to succeed:
```
[AddrInfo {addrFlags = [AI_ADDRCONFIG], addrFamily = AF_INET6,
                addrSocketType = Stream, addrProtocol = 6, addrAddress = [::1]:9042,
                addrCanonName = Nothing},
 AddrInfo {addrFlags = [AI_ADDRCONFIG],
                addrFamily = AF_INET, addrSocketType = Stream, addrProtocol = 6,
                addrAddress = 127.0.0.1:9042, addrCanonName = Nothing}]
```
