### PR TITLE
Mention OverloadedStrings in doc

### DIFF
--- a/src/Database/CQL/IO.hs
+++ b/src/Database/CQL/IO.hs
@@ -7,7 +7,7 @@
 -- <http://hackage.haskell.org/package/tinylog tinylog> for its logging
 -- output and expects a 'Logger'.
 --
--- For example:
+-- For example (here using the @OverloadedStrings@ extension) :
 --
 -- @
 -- > import Data.Text (Text)
@@ -23,6 +23,7 @@
 -- [Identity "3.2.0"]
 -- > shutdown c
 -- @
+--
 --
 -- __Note on prepared statements__
 --


### PR DESCRIPTION
Hi, 

I thought it would be nice to mention the extension in your example. The error GHC is throwing is not really helpful unless you go through the code. Feel free to reject, but would be nice if you left a note somewhere.
